### PR TITLE
Modernize PHP and Symfony support, CI and quality gates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+/.editorconfig     export-ignore
+/.gitattributes    export-ignore
+/.github/          export-ignore
+/.gitignore        export-ignore
+/phpstan.dist.neon export-ignore
+/phpunit.xml.dist  export-ignore
+/tests/            export-ignore
+/Makefile          export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,35 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    versioning-strategy: "widen"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+      phpstan:
+        patterns:
+          - "phpstan/*"
+      phpunit:
+        patterns:
+          - "phpunit/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,27 +9,40 @@ on:
       - "main" # merge to main assuming main branch is protected
   workflow_dispatch:
   schedule:
-    - cron: "37 13 * * 1" # daily at 13:37
+    - cron: "37 13 * * 1" # weekly, monday 13:37
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ci:
-    name: "Install dependencies and run tests"
-    runs-on: ${{ matrix.os }}
+  tests:
+    name: "Tests (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} dependencies)"
+    runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
       matrix:
+        # https://www.php.net/supported-versions.php
+        # https://github.com/shivammathur/setup-php#tada-php-support
         php-version:
-          # https://www.php.net/supported-versions.php
-          # https://github.com/shivammathur/setup-php#tada-php-support
           - "8.2"
           - "8.3"
+          - "8.4"
+          - "8.5"
         dependencies:
-          - "lowest"
           - "highest"
-        os:
-          - "ubuntu-latest"
+        include:
+          # Symfony 6.4.0 triggers "implicitly nullable parameter" deprecations on PHP >= 8.4,
+          # so the lowest allowed dependencies are only exercised on the lowest supported PHP.
+          - php-version: "8.2"
+            dependencies: "lowest"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
+
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -38,12 +51,86 @@ jobs:
           coverage: "none"
         env:
           fail-fast: true
-      - name: "Validate composer.json and composer.lock"
+
+      - name: "Validate composer.json"
         run: "composer validate --strict --no-interaction --ansi"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
+        uses: "ramsey/composer-install@v4"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
+
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --testdox"
+
+  coverage:
+    name: "Code coverage"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v7"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.4"
+          tools: "composer:v2"
+          coverage: "pcov"
+        env:
+          fail-fast: true
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v4"
+        with:
+          dependency-versions: "highest"
+
+      - name: "Run PHPUnit with coverage"
+        run: "vendor/bin/phpunit --coverage-text"
+
+  static-analysis:
+    name: "Static analysis"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v7"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.4"
+          tools: "composer:v2"
+          coverage: "none"
+        env:
+          fail-fast: true
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v4"
+        with:
+          dependency-versions: "highest"
+
+      - name: "Run PHPStan"
+        run: "vendor/bin/phpstan analyse --no-progress --error-format=github"
+
+  security:
+    name: "Security audit"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v7"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.4"
+          tools: "composer:v2"
+          coverage: "none"
+        env:
+          fail-fast: true
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v4"
+        with:
+          dependency-versions: "highest"
+
+      - name: "Run Composer audit"
+        run: "composer audit --no-interaction --ansi"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/vendor/
-composer.lock
+/composer.lock
+/config/reference.php
 /.phpunit.cache/
+/.php-cs-fixer.cache
 /var/
+/vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.DEFAULT_GOAL:=help
+
+.PHONY: dependencies
+dependencies: ## Install Composer dependencies
+	composer install --no-interaction --ansi
+
+.PHONY: test
+test: ## Run the test suite
+	vendor/bin/phpunit --testdox
+
+.PHONY: coverage
+coverage: ## Report the test coverage
+	vendor/bin/phpunit --coverage-text
+
+.PHONY: phpstan
+phpstan: ## Run static analysis
+	vendor/bin/phpstan analyse --no-progress
+
+.PHONY: audit
+audit: ## Check dependencies for known security vulnerabilities
+	composer audit --no-interaction --ansi
+
+.PHONY: qa
+qa: phpstan test audit ## Run all quality assurance checks
+
+# Based on https://suva.sh/posts/well-documented-makefiles/
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # mainlycode/health-bundle
 
+[![CI](https://github.com/mainlycode/health-bundle/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mainlycode/health-bundle/actions/workflows/ci.yml)
+
 Symfony bundle for adding a /health endpoint to your application
+
+## Requirements
+
+This bundle supports the PHP and Symfony versions that are officially supported
+by their maintainers:
+
+- [PHP](https://www.php.net/supported-versions.php) 8.2, 8.3, 8.4 and 8.5
+- [Symfony](https://symfony.com/releases) 6.4 LTS, 7.4 LTS and 8.1
 
 ## Installation
 
@@ -35,4 +45,14 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 return function (RoutingConfigurator $routes) {
     $routes->import('@HealthBundle/config/routing.yaml');
 };
+```
+
+## Contributing
+
+```
+make dependencies   # install the Composer dependencies
+make test           # run the test suite
+make coverage       # report the test coverage
+make phpstan        # run static analysis
+make qa             # run all quality assurance checks
 ```

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,17 @@
     ],
     "require": {
         "php": "^8.2",
-        "symfony/http-foundation": "^5.4||^6.4||^7.0"
+        "symfony/http-foundation": "^6.4||^7.4||^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.4",
-        "symfony/framework-bundle": "^5.4||^6.4||^7.0",
-        "symfony/browser-kit": "^5.4||^6.4||^7.0",
-        "symfony/yaml": "^5.4||^6.4||^7.0"
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.2",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.5||^12.5||^13.0",
+        "symfony/browser-kit": "^6.4||^7.4||^8.1",
+        "symfony/framework-bundle": "^6.4||^7.4||^8.1",
+        "symfony/runtime": "^6.4||^7.4||^8.1",
+        "symfony/yaml": "^6.4||^7.4||^8.1"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +34,10 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "symfony/runtime": true
+        },
         "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.5||^12.5||^13.0",
         "symfony/browser-kit": "^6.4||^7.4||^8.1",
-        "symfony/framework-bundle": "^6.4||^7.4||^8.1",
+        "symfony/framework-bundle": "^6.4.13||^7.4||^8.1",
         "symfony/runtime": "^6.4||^7.4||^8.1",
         "symfony/yaml": "^6.4||^7.4||^8.1"
     },

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: max
+    paths:
+        - src
+        - tests

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="false" beStrictAboutCoverageMetadata="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutCoverageMetadata="true"
+         requireCoverageMetadata="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         colors="true">
   <testsuites>
     <testsuite name="default">
       <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
-  <coverage/>
   <php>
     <server name="KERNEL_CLASS" value="MainlyCode\HealthBundle\TestKernel"/>
+    <server name="APP_DEBUG" value="0"/>
   </php>
   <source>
     <include>

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -6,7 +6,7 @@ namespace MainlyCode\HealthBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
-class HealthController
+final class HealthController
 {
     public function __invoke(): Response
     {

--- a/src/HealthBundle.php
+++ b/src/HealthBundle.php
@@ -6,7 +6,7 @@ namespace MainlyCode\HealthBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class HealthBundle extends Bundle
+final class HealthBundle extends Bundle
 {
     /** @see https://symfony.com/doc/current/bundles/best_practices.html#directory-structure */
     public function getPath(): string

--- a/tests/Controller/HealthControllerFunctionalTest.php
+++ b/tests/Controller/HealthControllerFunctionalTest.php
@@ -4,25 +4,43 @@ declare(strict_types=1);
 
 namespace MainlyCode\HealthBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use MainlyCode\HealthBundle\HealthBundle;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
-/** @group functional */
+#[CoversClass(HealthBundle::class)]
+#[CoversClass(HealthController::class)]
+#[Group('functional')]
 final class HealthControllerFunctionalTest extends WebTestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_a_200_ok(): void
     {
-        /** @var KernelBrowser $client */
         $client = static::createClient();
 
         $client->request('GET', '/health');
 
-        /** @var Response */
         $response = $client->getResponse();
 
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('👍', $response->getContent());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('👍', $response->getContent());
+    }
+
+    #[Test]
+    public function it_registers_the_route_under_the_bundle_path(): void
+    {
+        self::bootKernel();
+
+        $router = static::getContainer()->get('router');
+        self::assertInstanceOf(RouterInterface::class, $router);
+
+        $route = $router->getRouteCollection()->get('health');
+
+        self::assertNotNull($route);
+        self::assertSame('/health', $route->getPath());
     }
 }

--- a/tests/Controller/HealthControllerTest.php
+++ b/tests/Controller/HealthControllerTest.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace MainlyCode\HealthBundle\Controller;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+#[CoversClass(HealthController::class)]
 final class HealthControllerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_a_200_ok(): void
     {
         $controller = new HealthController();
 
-        /** @var Response */
         $response = $controller();
 
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('👍', $response->getContent());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('👍', $response->getContent());
     }
 }

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -7,6 +7,7 @@ namespace MainlyCode\HealthBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
@@ -14,12 +15,11 @@ final class TestKernel extends Kernel
 {
     use MicroKernelTrait;
 
-    public function registerBundles(): array
+    /** @return iterable<BundleInterface> */
+    public function registerBundles(): iterable
     {
-        return [
-            new FrameworkBundle(),
-            new HealthBundle(),
-        ];
+        yield new FrameworkBundle();
+        yield new HealthBundle();
     }
 
     protected function configureContainer(ContainerConfigurator $c): void


### PR DESCRIPTION
Maintenance sweep so the repo can be left alone and CI/Dependabot report what breaks.

## Supported versions

Taken from [php.net](https://www.php.net/supported-versions.php) and `symfony.com/releases.json`:

- PHP stays at `^8.2`; the matrix now covers 8.2, 8.3, 8.4 and 8.5. **8.2 leaves security support on 31 Dec 2026** and should be dropped then.
- Symfony `^5.4||^6.4||^7.0` → `^6.4||^7.4||^8.1`. 5.4, 7.0–7.3 and 8.0 are end of life; `^7.0` would have silently readmitted the dead 7.x minors.

## Tests

The suite was running **zero tests** — PHPUnit 13 removed the `@test`/`@group` annotations, so every class reported "No tests found". Migrated to attributes, added `#[CoversClass]` with `requireCoverageMetadata="true"`, and switched `assertEquals` → `assertSame`.

PHPUnit is now `^11.5||^12.5||^13.0` so Composer resolves per PHP version (12 needs 8.3, 13 needs 8.4). The XML schema is pinned to 11.5 so the config parses under all three.

Two Symfony interactions fixed at the source rather than silenced:

- `symfony/runtime` added to `require-dev`. Without it `FrameworkBundle::boot()` registers an `ErrorHandler` it never restores, which PHPUnit reports as *"Test code or tested code did not remove its own exception handlers"*.
- `APP_DEBUG=0` in `phpunit.xml.dist`, which also stops Symfony 8 writing a generated `config/reference.php` into the working tree.

Added a functional test covering that the routing file resolves through the bundle path — the one integration seam that had no coverage.

Coverage is currently **100%** (2/2 classes, 2/2 methods, 2/2 statements). CI reports the figure on every run; there is deliberately no threshold gate.

## Static analysis and security

- **PHPStan** at `level: max` with **no baseline**, over `src` and `tests`.
- **`composer audit`** runs in CI.

## CI

Updated to current action majors (`checkout` v4→v7, `composer-install` v3→v4), added workflow-level `permissions`, a `concurrency` group that cancels superseded PR runs, `fail-fast: false`, and separate coverage / static-analysis / security jobs.

The lowest-dependency leg now runs **only on PHP 8.2**. Symfony 6.4.0 emits implicit-nullable-parameter deprecations on PHP ≥ 8.4 — verified locally; it is not fixable here and no consumer will hit it.

## Dependabot

Grouped by family (symfony / phpstan / phpunit / actions), capped, `versioning-strategy: widen` as befits a library, and conventional-commit prefixes.

## Housekeeping

`.gitattributes` with `export-ignore`, a `Makefile` (`make test|coverage|phpstan|audit|qa`), README badge and Requirements section, gitignore entries for cache/generated files, and removal of the committed `.php-cs-fixer.cache`.

## Breaking change

`HealthBundle` and `HealthController` are now `final`. Neither is designed for inheritance — the endpoint is configured by importing the routing file. Last tag is `0.4.0`, so this releases as **0.5.0**.